### PR TITLE
Adding loading screen, case with no notes, and server error handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Note as NoteModel } from "./models/note";
-import { Button, Col, Container, Row } from "react-bootstrap";
+import { Button, Col, Container, Row, Spinner } from "react-bootstrap";
 import Note from "./components/Note";
 import styles from "./styles/NotesPage.module.css";
 import styleUtils from "./styles/utils.module.css";
@@ -10,19 +10,24 @@ import { FaPlus } from "react-icons/fa";
 
 function App() {
     const [notes, setNotes] = useState<NoteModel[]>([]);
-
+    const [notesLoading, setNotesLoading] = useState(true);
+    const [showNotesLoadingError, setShowNotesLoadingError] = useState(false);
+    
     const [showAddNoteDialog, setShowAddNoteDialog] = useState(false);
-
     const [noteToEdit, setNoteToEdit] = useState<NoteModel | null>(null);
 
     useEffect(() => {
         async function loadNotes() {
             try {
+                setShowNotesLoadingError(false);
+                setNotesLoading(true);
                 const notes = await NotesAPI.fetchNotes();
                 setNotes(notes);
             } catch (error) {
                 console.error(error);
-                alert(error);
+                setShowNotesLoadingError(true);
+            } finally {
+                setNotesLoading(false);
             }
         }
         loadNotes();
@@ -38,8 +43,22 @@ function App() {
         }
     }
 
+    const notesGrid =
+        <Row xs={1} md={2} xl={3} className={`g-4 ${styles.notesGrid}`}>
+            {notes.map((note) => (
+                <Col key={note._id}>
+                    <Note
+                        note={note}
+                        onNoteClicked={setNoteToEdit}
+                        onDeleteNoteClick={deleteNote}
+                        className={styles.note}
+                    />
+                </Col>
+            ))}
+        </Row>
+
     return (
-        <Container>
+        <Container className={styles.notesPage}>
             <Button
                 className={`mb-4 ${styleUtils.blockCenter} ${styleUtils.flexcenter}`}
                 onClick={() => setShowAddNoteDialog(true)}
@@ -47,18 +66,16 @@ function App() {
                 <FaPlus />
                 Add New Note
             </Button>
-            <Row xs={1} md={2} xl={3} className="g-4">
-                {notes.map((note) => (
-                    <Col key={note._id}>
-                        <Note
-                            note={note}
-                            onNoteClicked={setNoteToEdit}
-                            onDeleteNoteClick={deleteNote}
-                            className={styles.note}
-                        />
-                    </Col>
-                ))}
-            </Row>
+            {notesLoading && <Spinner animation="border" variant="primary" />} 
+            {showNotesLoadingError && <p>Something went wront. Please refresh the page</p>}
+            {!notesLoading && !showNotesLoadingError &&
+            <>
+            { notes.length > 0
+                ? notesGrid
+                : <p>You do not have any notes yet</p>
+            }
+            </>
+            }
             {showAddNoteDialog && (
                 <AddEditNotesDialog
                     onDismiss={() => setShowAddNoteDialog(false)}

--- a/frontend/src/styles/NotesPage.module.css
+++ b/frontend/src/styles/NotesPage.module.css
@@ -1,3 +1,13 @@
+.notesPage {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.notesGrid {
+    width: 100%;
+}
+
 .note {
     height: 200px;
     min-width: 150px;


### PR DESCRIPTION
Added a loading animation until note's fetch request arrives. When there are no notes to show, we display a message, when there is a server error, we prompt the user to refresh the page. Also changed styling of notes and grid.